### PR TITLE
Fix forum quoting

### DIFF
--- a/base.css
+++ b/base.css
@@ -4043,11 +4043,13 @@ blockquote.ow_quote .ow_author{
     padding: 2px 0;
     width: 98%;
 }
+body.htmlarea_styles .ow_quote_header,
 .ow_quote_header {
 	display: block;
 	padding: 6px;
 	background-color: #cad4dd;
 }
+body.htmlarea_styles .ow_quote_cont_wrap,
 .ow_quote_cont_wrap {
 	background: url("images/quote_top.png") no-repeat right 1px;
     border-color: #eff2f5;
@@ -4055,6 +4057,7 @@ blockquote.ow_quote .ow_author{
     border-width: 0 1px 1px;
     display: block;
 }
+body.htmlarea_styles .ow_quote_cont,
 .ow_quote_cont {
 	background: url("images/quote_bottom.png") no-repeat 1px bottom;
     display: block;


### PR DESCRIPTION
Tested with oxwall 1.8.3

Quoting text resulted partly  in white on white content in the edit window, because several css rules didn't apply to content in the dynamically created iframe.